### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.3] - 2026-02-21
+
+### 💼 Other
+
+- Potential fix for code scanning alert no. 1: Workflow does not contain permissions
+- 🔒️ security(zeroize-buf): zeroize some sec buf
+
+### 📚 Documentation
+
+- 📝 docs(README): fix doc test
+
 ## [0.1.2] - 2026-02-20
 
 ### 🚀 Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mini-sign"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = ["wind_mask"]
 description = "A crate for minisign in rust."


### PR DESCRIPTION



## 🤖 New release

* `mini-sign`: 0.1.2 -> 0.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3] - 2026-02-21

### 💼 Other

- Potential fix for code scanning alert no. 1: Workflow does not contain permissions
- 🔒️ security(zeroize-buf): zeroize some sec buf

### 📚 Documentation

- 📝 docs(README): fix doc test
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).