### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,8 @@
 name: Rust
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/wind-mask/minisign-rs/security/code-scanning/1](https://github.com/wind-mask/minisign-rs/security/code-scanning/1)

In general, fix this by declaring an explicit `permissions` block that grants only the minimal required scopes for the workflow. Since this workflow just checks out the repository, builds, tests, and runs a semver check action, it only needs read access to repository contents.

The simplest, least disruptive change is to add a root-level `permissions` block right after the `name:` (or before `jobs:`). This will apply to all jobs in the workflow that do not define their own permissions. For this specific file, add:

```yaml
permissions:
  contents: read
```

near the top, e.g. after line 2. No changes to existing steps or functionality are required, and no additional imports or methods are needed because this is a GitHub Actions configuration file, not application code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
